### PR TITLE
Added basic google-auth and bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,22 @@
+download(){
+    if [ ! -f bootstrap-3.3.2-dist.zip ]
+    then
+        wget https://github.com/twbs/bootstrap/releases/download/v3.3.2/bootstrap-3.3.2-dist.zip
+    fi
+    unzip bootstrap-3.3.2-dist.zip
+}
+
+if [ \( -d "static/css" \) -a \( -d "static/js" \) -a \( -d "static/fonts" \) ]
+then 
+    echo -e "All the css, js and font directory are present.\nExiting without doing nothing."
+else 
+    echo -e "js or css or fonts directory not present.\n Using bootstrap to populate."
+    download
+    if [ ! -d "static" ]
+    then
+        mkdir static
+    fi
+    mv bootstrap-3.3.2-dist/* static/
+    rmdir bootstrap-3.3.2-dist
+    rm bootstrap-3.3.2-dist.zip
+fi

--- a/google-auth/urls.py
+++ b/google-auth/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import patterns, include, url
+
+from django.contrib import admin
+admin.autodiscover()
+
+urlpatterns = patterns('',
+   url(r'^$', 'google-auth.views.home', name='home'),
+      url(r'^admin/', include(admin.site.urls)),
+      )

--- a/google-auth/views.py
+++ b/google-auth/views.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render_to_response
+from django.template.context import RequestContext
+
+def home(request):
+   context = RequestContext(request,
+                           {'user': request.user,
+                             'request': request})
+   return render_to_response('google-auth/home.html',
+                             context_instance=context)

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'portalapp',
+    'google-auth',
+    'social.apps.django_app.default',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -47,6 +49,25 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+   'django.contrib.auth.context_processors.auth',
+   'django.core.context_processors.debug',
+   'django.core.context_processors.i18n',
+   'django.core.context_processors.media',
+   'django.core.context_processors.static',
+   'django.core.context_processors.tz',
+   'django.contrib.messages.context_processors.messages',
+   'social.apps.django_app.context_processors.backends',
+   'social.apps.django_app.context_processors.login_redirect',
+)
+
+AUTHENTICATION_BACKENDS = (
+   'social.backends.facebook.FacebookOAuth2',
+   'social.backends.google.GoogleOAuth2',
+   'social.backends.twitter.TwitterOAuth',
+   'django.contrib.auth.backends.ModelBackend',
 )
 
 ROOT_URLCONF = 'portal.urls'
@@ -81,4 +102,16 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
+STATIC_PATH = os.path.join(BASE_DIR, 'static')
 STATIC_URL = '/static/'
+STATICFILES_DIRS = (
+    STATIC_PATH,
+)
+TEMPLATE_PATH = os.path.join(BASE_DIR, 'templates')
+TEMPLATE_DIRS = [
+    TEMPLATE_PATH,
+]
+
+LOGIN_REDIRECT_URL = '/'
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = '806044360050-t85dh7evo00u3rglp8vdqpjm6ohig6g4.apps.googleusercontent.com'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'kCl5omjKCD5PewVCP0ZCgjyU'

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -9,5 +9,11 @@ urlpatterns = patterns(
 
     url(r'^admin/', include(admin.site.urls)),
 
-    url(r'^$', include('portalapp.urls'))
+    url(r'^$', include('portalapp.urls')),
+
+    url(r'^auth/', include('google-auth.urls')),
+
+    url('', include('social.apps.django_app.urls', namespace='social')),
+
+    url('', include('django.contrib.auth.urls', namespace='auth')),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==1.7.3
+python-social-auth

--- a/templates/google-auth/base.html
+++ b/templates/google-auth/base.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+   <meta charset="utf-8">
+   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+   <meta name="viewport" content="width=device-width, initial-scale=1">
+   <title>{% block title %}Third-party Authentication Tutorial{% endblock %}</title>
+
+   <!-- Bootstrap -->
+   <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+   <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
+
+   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+   <!--[if lt IE 9]>
+     <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+   <![endif]-->
+ </head>
+ <body>
+   {% block main %}{% endblock %}
+   <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+   <!-- Include all compiled plugins (below), or include individual files as needed -->
+   <script src="/static/js/bootstrap.min.js"></script>
+ </body>
+</html>

--- a/templates/google-auth/home.html
+++ b/templates/google-auth/home.html
@@ -1,0 +1,24 @@
+{% extends 'google-auth/base.html' %}
+
+{% block main %}
+ <div>
+ <h1>Gmail Auth</h1>
+
+ <p>
+   <ul>
+   {% if user and not user.is_anonymous %}
+     <li>
+       <a>Hello {{ user.get_full_name|default:user.username }}!</a>
+     </li>
+     <li>
+       <a href="{% url 'auth:logout' %}?next={{ request.path }}">Logout</a>
+     </li>
+   {% else %}
+     <li>
+       <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">Login with Google</a>
+     </li>
+   {% endif %}
+   </ul>
+ </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
A new library called python-social-auth is added. Right
now the basic login with google account works.
You need to create an application with google and
use its secret and access. For testing purpose I
am adding my keys and secret here. Please don't
misuse it.

Add an entry in your /etc/hosts file which should
look like:
127.0.0.1   iithalumni.com

The reason for doing the above thing is a redirect url
is needed after google login and it shouldn't be
localhost or 127.0.0.1

Check it out in action by visiting:
http://iithalumni.com:8000/auth/

For initial bootstrapping run
bash bootstrap.sh